### PR TITLE
[ECS 14] HabitColor 구현

### DIFF
--- a/Habit Management/Core/Extension/Color.swift
+++ b/Habit Management/Core/Extension/Color.swift
@@ -9,20 +9,41 @@ import SwiftUI
 
 extension Color {
     init(hex: String) {
-        let scanner = Scanner(string: hex)
-        _ = scanner.scanString("#")
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
         
-        var rgb: UInt64 = 0
-        scanner.scanHexInt64(&rgb)
+        let r, g, b: Double
+        r = Double((int >> 16) & 0xFF) / 255
+        g = Double((int >> 8) & 0xFF) / 255
+        b = Double(int & 0xFF) / 255
         
-        let r = Double((rgb >> 16) & 0xFF) / 255.0
-        let g = Double((rgb >> 8) & 0xFF) / 255.0
-        let b = Double((rgb >> 0) & 0xFF) / 255.0
         self.init(red: r, green: g, blue: b)
     }
-    
-    enum HabitColor: String {
-        case primary = "#639F70"
+}
+
+enum HabitColor {
+    case defaultGray
+    case defaultGreen
+    case lightGreen
+    case mediumGreen
+    case darkGreen
+}
+
+extension HabitColor {
+    var color: Color {
+        switch self {
+        case .defaultGray:
+            return Color(hex: "E6E6E6")
+        case .defaultGreen:
+            return Color(hex: "639F70")
+        case .lightGreen:
+            return Color(hex: "D5EBD3")
+        case .mediumGreen:
+            return Color(hex: "9ECAA4")
+        case .darkGreen:
+            return Color(hex: "36793F")
+        }
     }
 }
 

--- a/Habit Management/Core/ViewModifier/FillColorModifier.swift
+++ b/Habit Management/Core/ViewModifier/FillColorModifier.swift
@@ -17,7 +17,7 @@ struct FillColorModifier<S: Shape>: ViewModifier {
 }
 
 extension Shape {
-    func fillColor(_ color: Color.HabitColor) -> some View {
-        modifier(FillColorModifier(shape: self, hexColor: color.rawValue))
+    func fillColor(_ color: String) -> some View {
+        modifier(FillColorModifier(shape: self, hexColor: color))
     }
 }

--- a/Habit Management/Feature/Calendar/CalendarBackground/CalendarBackgroundView.swift
+++ b/Habit Management/Feature/Calendar/CalendarBackground/CalendarBackgroundView.swift
@@ -18,7 +18,7 @@ struct CalendarBackgroundView<Content: View>: View {
         VStack(spacing: 0) {
             content
         }
-        .background(Color(hex: Color.HabitColor.primary.rawValue))
+        .background(HabitColor.defaultGreen.color)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .scaledPadding(top: 0, leading: 16, bottom: 0, trailing: 16)
     }

--- a/Habit Management/Feature/Calendar/CalendarGrid/CalendarGridView.swift
+++ b/Habit Management/Feature/Calendar/CalendarGrid/CalendarGridView.swift
@@ -49,13 +49,13 @@ struct CalendarGridView: View {
         let percent = (Double(count)/Double(total))*Double(100)
         
         if count == 0 {
-            return Color(hex: "#E6E6E6")
+            return HabitColor.defaultGray.color
         } else if percent < 33 {
-            return Color(hex: "#D5EBD3")
+            return HabitColor.lightGreen.color
         } else if percent > 33 && percent < 66 {
-            return Color(hex: "#9ECAA4")
+            return HabitColor.mediumGreen.color
         } else {
-            return Color(hex: "#36793F")
+            return HabitColor.darkGreen.color
         }
     }
 }
@@ -64,7 +64,7 @@ struct CalendarGridView: View {
 extension CalendarGridView {
     func gridItem(_ date: String) -> some View {
         RoundedRectangle(cornerRadius: setting.ratioSpacing)
-            .fill(date == "" ? Color(hex: "#639F70"): getColor(date: date))
+            .fill(date == "" ? HabitColor.defaultGreen.color : getColor(date: date))
             .scaledFrame(width: setting.frameSize, height: setting.frameSize)
     }
 }

--- a/Habit Management/Feature/Calendar/CalendarLevel/CalendarLevelView.swift
+++ b/Habit Management/Feature/Calendar/CalendarLevel/CalendarLevelView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct CalendarLevelView: View {
-    private let levelHex = ["#E6E6E6", "#D5EBD3", "#9ECAA4", "#36793F"]
+    private let HabitLevel: [HabitColor] = [.defaultGray, .lightGreen, .mediumGreen, .darkGreen]
     
     var body: some View {
         HStack(spacing: 4) {
             Spacer()
             levelLabel("LEVEL")
-            level(for: levelHex)
+            level(for: HabitLevel)
         }
         .scaledPadding(top: 0, leading: 0, bottom: 12, trailing: 20)
     }
@@ -28,11 +28,11 @@ extension CalendarLevelView {
             .scaledText(size: 12, weight: .bold)
     }
     
-    private func level(for colors: [String]) -> some View {
+    private func level(for colors: [HabitColor]) -> some View {
         HStack(spacing: 3) {
             ForEach(colors, id: \.self) { color in
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .foregroundColor(Color(hex: color))
+                    .foregroundColor(color.color)
                     .scaledFrame(width: 12, height: 12, isScroll: true)
             }
         }

--- a/Habit Management/Feature/Calendar/CalendarScrollView.swift
+++ b/Habit Management/Feature/Calendar/CalendarScrollView.swift
@@ -15,6 +15,8 @@ struct CalendarScrollView: View {
     
     @EnvironmentObject var setting: Setting
     
+    @Namespace private var scrollID
+    
     init(calendarStore: StoreOf<CalendarFeature>) {
         self.calendarStore = calendarStore
         self.calendarMonthStore = calendarStore.scope(state: \.month, action: \.month)
@@ -30,10 +32,10 @@ struct CalendarScrollView: View {
                         CalendarGridView(store: calendarGridStore)
                     }
                 }
-                .id("scrollContent")
+                .id(scrollID)
             }
             .onAppear() {
-                proxy.scrollTo("scrollContent", anchor: .trailing)
+                proxy.scrollTo(scrollID, anchor: .trailing)
             }
         }
     }

--- a/Habit Management/Feature/Habit/HabitBackground/HabitBackgroundView.swift
+++ b/Habit Management/Feature/Habit/HabitBackground/HabitBackgroundView.swift
@@ -17,7 +17,7 @@ struct HabitBackgroundView<Content: View>: View {
     var body: some View {
         ZStack(alignment: .topLeading) {
             Rectangle()
-                .fill(Color(hex: "#B8D9B9"))
+                .fill(HabitColor.mediumGreen.color)
                 .edgesIgnoringSafeArea(.all)
                 .scaledFrame(width: nil, height: 242)
             

--- a/Habit Management/Feature/Habit/HabitHeader/HabitHeaderView.swift
+++ b/Habit Management/Feature/Habit/HabitHeader/HabitHeaderView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 import ComposableArchitecture
 
 struct HabitHeaderView: View {
-    let store: StoreOf<HabitHeaderFeature>
+    private let habitHeaderStore: StoreOf<HabitHeaderFeature>
     
-    init(store: StoreOf<HabitHeaderFeature>) {
-        self.store = store
+    init(habitStore: StoreOf<HabitFeature>) {
+        self.habitHeaderStore = habitStore.scope(state: \.header, action: \.header)
     }
     
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
+        WithViewStore(habitHeaderStore, observe: { $0 }) { viewStore in
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(viewStore.userName)님!")

--- a/Habit Management/Feature/Habit/HabitView.swift
+++ b/Habit Management/Feature/Habit/HabitView.swift
@@ -26,7 +26,7 @@ struct HabitView: View {
         WithViewStore(habitStore, observe: { $0 }) { viewStore in
             HabitBackgroundView {
                 VStack(spacing: 16) {
-                    HabitHeaderView(store: habitStore.scope(state: \.header, action: \.header))
+                    HabitHeaderView(habitStore: habitStore)
                     CalendarView(calendarStore: calendarStore)
                     MainToggleBar(
                         showAll: viewStore.binding(

--- a/Habit Management/Feature/Statistics/View/Scroll/ThisWeekView.swift
+++ b/Habit Management/Feature/Statistics/View/Scroll/ThisWeekView.swift
@@ -30,7 +30,7 @@ struct ThisWeekView: View {
                         .scaledFrame(width: frame_size, height: frame_size)
                         .overlay(
                             RoundedRectangle(cornerRadius: ratioSpacing, style: .continuous)
-                                .fill(date == "" ? Color(hex: "#639F70"): getColor(date))
+                                .fill(date == "" ? HabitColor.defaultGreen.color : getColor(date))
                                 .scaledFrame(width: frame_size, height: frame_size)
                         )
                 }


### PR DESCRIPTION
## 요약

- 기존 HexColor 로직을 점검, 수정하였습니다.
- 자주 사용하는 Color들을 HabitColor enum으로 정리하였습니다.

## Code

Color Extension

```
extension Color {
    init(hex: String) {
        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
        var int: UInt64 = 0
        Scanner(string: hex).scanHexInt64(&int)
        
        let r, g, b: Double
        r = Double((int >> 16) & 0xFF) / 255
        g = Double((int >> 8) & 0xFF) / 255
        b = Double(int & 0xFF) / 255
        
        self.init(red: r, green: g, blue: b)
    }
}
```

HabitColor Extension

```
enum HabitColor {
    case defaultGray
    case defaultGreen
    case lightGreen
    case mediumGreen
    case darkGreen
}

extension HabitColor {
    var color: Color {
        switch self {
        case .defaultGray:
            return Color(hex: "E6E6E6")
        case .defaultGreen:
            return Color(hex: "639F70")
        case .lightGreen:
            return Color(hex: "D5EBD3")
        case .mediumGreen:
            return Color(hex: "9ECAA4")
        case .darkGreen:
            return Color(hex: "36793F")
        }
    }
}
```
